### PR TITLE
Fix time zone issues in epgxmltv

### DIFF
--- a/plugin/controllers/views/web/epgxmltv.tmpl
+++ b/plugin/controllers/views/web/epgxmltv.tmpl
@@ -1,5 +1,5 @@
 #filter WebSafe
-#from datetime import datetime
+#from datetime import datetime, timezone
 <?xml version="1.0" encoding="UTF-8"?>
 <tv source-info-url="https://github.com/oe-alliance/OpenWebif" source-info-name="OpenWebif">
 	#for $service in $services
@@ -8,7 +8,7 @@
 	</channel>
 	#end for
 	#for $event in $events
-	<programme start="$datetime.fromtimestamp($event.begin_timestamp).strftime('%Y%m%d%H%M%S') $offset.utcoffset" stop="$datetime.fromtimestamp($event.begin_timestamp + $event.duration_sec).strftime('%Y%m%d%H%M%S') $offset.utcoffset" channel="$event.sref">
+	<programme start="$datetime.fromtimestamp($event.begin_timestamp, timezone.utc).astimezone().strftime('%Y%m%d%H%M%S %z')" stop="$datetime.fromtimestamp($event.begin_timestamp + $event.duration_sec, timezone.utc).astimezone().strftime('%Y%m%d%H%M%S %z')" channel="$event.sref">
 		<title lang="$lang">$str($event.title)</title>
 		<sub-title lang="$lang">$str($event.shortdesc)</sub-title>
 		<desc lang="$lang">$str($event.longdesc)</desc>

--- a/plugin/controllers/views/web/epgxmltv.tmpl
+++ b/plugin/controllers/views/web/epgxmltv.tmpl
@@ -8,7 +8,7 @@
 	</channel>
 	#end for
 	#for $event in $events
-	<programme start="$datetime.utcfromtimestamp($event.begin_timestamp).strftime('%Y%m%d%H%M%S') $offset.utcoffset" stop="$datetime.utcfromtimestamp($event.begin_timestamp + $event.duration_sec).strftime('%Y%m%d%H%M%S') $offset.utcoffset" channel="$event.sref">
+	<programme start="$datetime.fromtimestamp($event.begin_timestamp).strftime('%Y%m%d%H%M%S') $offset.utcoffset" stop="$datetime.fromtimestamp($event.begin_timestamp + $event.duration_sec).strftime('%Y%m%d%H%M%S') $offset.utcoffset" channel="$event.sref">
 		<title lang="$lang">$str($event.title)</title>
 		<sub-title lang="$lang">$str($event.shortdesc)</sub-title>
 		<desc lang="$lang">$str($event.longdesc)</desc>

--- a/plugin/controllers/web.py
+++ b/plugin/controllers/web.py
@@ -32,7 +32,7 @@ from .models.locations import getLocations, getCurrentLocation, addLocation, rem
 from .models.timers import getTimers, addTimer, addTimerByEventId, editTimer, removeTimer, toggleTimerStatus, cleanupTimer, writeTimerList, recordNow, tvbrowser, getSleepTimer, setSleepTimer, getPowerTimer, setPowerTimer, getVPSChannels
 from .models.message import sendMessage, getMessageAnswer
 from .models.movies import getMovieList, removeMovie, getMovieInfo, movieAction, getAllMovies, getMovieDetails, setMovieResumePoint, MOVIETAGFILE
-from .models.config import getSettings, addCollapsedMenu, removeCollapsedMenu, saveConfig, getConfigs, getConfigsSections, getUtcOffset
+from .models.config import getSettings, addCollapsedMenu, removeCollapsedMenu, saveConfig, getConfigs, getConfigsSections
 from .models.stream import getStream, getTS, getStreamSubservices, GetSession
 from .models.servicelist import reloadServicesLists
 from .models.mediaplayer import mediaPlayerAdd, mediaPlayerRemove, mediaPlayerPlay, mediaPlayerCommand, mediaPlayerCurrent, mediaPlayerList, mediaPlayerLoad, mediaPlayerSave, mediaPlayerFindFile
@@ -1600,7 +1600,6 @@ class WebController(BaseController):
 		bref = getUrlArg(request, "bRef")
 		ret["services"] = getServices(bref, True, False)["services"]
 		ret["lang"] = getUrlArg(request, "lang")
-		ret["offset"] = getUtcOffset()
 		return ret
 
 	# http://enigma2/api/epgnow?bRef=1%3A7%3A1%3A0%3A0%3A0%3A0%3A0%3A0%3A0%3A%20FROM%20BOUQUET%20"userbouquet.favourites.tv"%20ORDER%20BY%20bouquet


### PR DESCRIPTION
The start and stop timestamps were previously formatted/specified in UTC. This was incorrect, because the offset of the local timezone is appended to these timestamps, causing consumers to interpret the formatted UTC timestamps in another time zone instead.

Timestamps are now put out in the local time zone, matching the appended time zone offset. Furthermore, edge cases, where the time zone offset of some timestamp does not match the current time zone offset (for example due to DST), are now also handled correctly.