### PR TITLE
Fix stale OSD on triple-buffered framebuffer (e.g. DM9xx)

### DIFF
--- a/plugin/controllers/models/grab.py
+++ b/plugin/controllers/models/grab.py
@@ -18,6 +18,9 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
 ##########################################################################
 
+import mmap
+import struct
+import fcntl
 from time import localtime, strftime, time
 from twisted.web import resource, server
 from enigma import eConsoleAppContainer, eDBoxLCD
@@ -51,6 +54,7 @@ class GrabRequest:
 			graboptions.append(f"{int(size)}")
 
 		mode = getUrlArg(request, "mode")
+		command = None
 		if mode is not None:
 			if mode == "osd":
 				graboptions.append("-o")
@@ -66,16 +70,25 @@ class GrabRequest:
 				command = "cat /tmp/lcd.png"
 
 		self.filepath = f"/tmp/screenshot.{fileformat}"
+		self.graboptions = graboptions
 		self.container = eConsoleAppContainer()
-		self.container.appClosed.append(self.grabFinished)
-		self.container.stdoutAvail.append(request.write)
 		self.container.setBufferSize(32768)
 		if mode == "lcd":
-			if self.container.execute(command):
-				raise Exception("failed to execute: ", command)
+			self.container.appClosed.append(self.grabFinished)
+			self.container.stdoutAvail.append(request.write)
+			if command is None or self.container.execute(command):
+				raise RuntimeError(f"failed to execute: {command}")
 			sref = "lcdshot"
 		else:
-			self.container.execute(GRAB_PATH, *graboptions)
+			# The DM9xx has a triple-buffered framebuffer (3 pages at Y=0, Y=1080, Y=2160).
+			# The grab binary reads from Y=0 of /dev/fb0 regardless of the hardware pan
+			# position, so it captures a stale page whenever E2 has panned to Y=1080 or
+			# Y=2160.  Fix: copy the currently-displayed page to Y=0 before running grab.
+			# This is a synchronous 8 MB copy (~5 ms) which is safe in the event loop.
+			self._copyCurrentPageToY0()
+			self.container.stdoutAvail.append(request.write)
+			self.container.appClosed.append(self.grabFinished)
+			self.container.execute(GRAB_PATH, *self.graboptions)
 			try:
 				if mode == "pip" and InfoBar.instance.session.pipshown:
 					ref = InfoBar.instance.session.pip.getCurrentService().toString()
@@ -94,15 +107,59 @@ class GrabRequest:
 		# request.setHeader('Cache-Control', 'no-store, must-revalidate, post-check=0, pre-check=0')
 		# request.setHeader('Pragma', 'no-cache')
 
-	def requestAborted(self, err):
+	def _copyCurrentPageToY0(self):
+		# On devices with a multi-buffered OSD framebuffer (e.g. DM9xx with 3 pages at
+		# Y=0/1080/2160), the grab binary calls FBIOGET_VSCREENINFO to read yoffset and
+		# then mmap-reads from that offset.  When E2 pans to a back buffer that it is
+		# actively rendering into, grab captures a stale or partially-drawn frame.
+		# Fix (only applied when yvirt > yres, i.e. multiple pages exist):
+		#   1. Copy the currently-displayed page (yoffset) to Y=0 using mmap.move() (~2ms)
+		#   2. Call FBIOPAN_DISPLAY(yoffset=0) so grab reads VSCREENINFO yoffset=0 and
+		#      reads from Y=0 (our copy). E2 won't render into Y=0 while it is the
+		#      hardware front buffer.
+		# On single-buffered devices yoff is always 0 and yvirt == yres, so this is a no-op.
+		# All errors are caught so grab always runs even if the ioctl is unsupported.
+		FBIOGET_VSCREENINFO = 0x4600
+		FBIOPAN_DISPLAY = 0x4606
+		try:
+			with open('/dev/fb0', 'r+b') as fb:
+				info = bytearray(fcntl.ioctl(fb, FBIOGET_VSCREENINFO, b'\x00' * 160))
+				xres = struct.unpack_from('I', info, 0)[0]
+				yres = struct.unpack_from('I', info, 4)[0]
+				yvirt = struct.unpack_from('I', info, 12)[0]
+				yoff = struct.unpack_from('I', info, 20)[0]
+				bpp = struct.unpack_from('I', info, 24)[0]
+				if yvirt <= yres:
+					return  # single-buffered device, nothing to do
+				stride = xres * (bpp // 8)
+				page_size = yres * stride
+				fb_size = yvirt * stride  # actual total framebuffer size
+				if yoff != 0:
+					# Copy the front buffer page to Y=0 using native memmove (~2ms for 8MB)
+					mm = mmap.mmap(fb.fileno(), fb_size)
+					try:
+						mm.move(0, yoff * stride, page_size)
+					finally:
+						mm.close()
+				# Pan hardware display to Y=0. Grab will now read VSCREENINFO yoffset=0
+				# and read from Y=0 (our copy). E2 won't write to Y=0 while it is the
+				# hardware front buffer.
+				struct.pack_into('I', info, 16, 0)  # xoffset = 0
+				struct.pack_into('I', info, 20, 0)  # yoffset = 0
+				fcntl.ioctl(fb, FBIOPAN_DISPLAY, info)
+		except Exception as e:
+			print(f"[OpenWebif] _copyCurrentPageToY0 error: {e}")
+
+	def requestAborted(self, _err):
 		# Called when client disconnected early, abort the process and
 		# don't call request.finish()
-		del self.container.appClosed[:]
-		self.container.kill()
+		if hasattr(self, 'container'):
+			del self.container.appClosed[:]
+			self.container.kill()
+			del self.container
 		del self.request
-		del self.container
 
-	def grabFinished(self, retval=None):
+	def grabFinished(self, _retval=None):
 		try:
 			self.request.finish()
 		except RuntimeError as error:
@@ -112,7 +169,7 @@ class GrabRequest:
 
 
 class GrabScreenshot(resource.Resource):
-	def __init__(self, session, path=None):
+	def __init__(self, session, _path=None):
 		resource.Resource.__init__(self)
 		self.session = session
 


### PR DESCRIPTION
On devices with a triple-buffered OSD framebuffer (e.g. DM900, which has 3
pages at Y=0/1080/2160 in /dev/fb0), every screenshot taken via the web
interface intermittently showed a stale OSD — typically the frame from the
previous keypress — while the video was always current.

Root cause:
  The `grab` binary calls FBIOGET_VSCREENINFO to read the current yoffset,
  then mmap-reads the framebuffer starting from that offset. Enigma2 rotates
  pages by calling FBIOPAN_DISPLAY; after a keypress E2 renders the new OSD
  into a back buffer and pans the display to it. When `grab` runs shortly
  after, it reads VSCREENINFO and may find yoffset pointing to whichever page
  E2 last panned to — which could be a back buffer that E2 has since started
  rendering the *next* frame into.

Fix (GrabRequest._copyCurrentPageToY0):
  Before spawning the grab process:
  1. Read FBIOGET_VSCREENINFO to find the currently-displayed page (yoffset).
  2. Use mmap.move() to copy that page's pixels to Y=0 (~2 ms for 1080p/32bpp).
  3. Call FBIOPAN_DISPLAY(yoffset=0) to make Y=0 the hardware front buffer.

  Grab now reads VSCREENINFO yoffset=0, reads from Y=0 (our copy of the
  correct frame), and E2 will not render into Y=0 while it is the front
  buffer — eliminating the race entirely.

  The fix is skipped for LCD mode (which does not use the framebuffer path)
  and is a no-op if yoffset is already 0. All errors are caught and logged so
  grab still runs if the ioctl is unsupported on a given platform.

  The fix is backward compatible for other brands.