### PR TITLE
Update main.tmpl according original key codes of gbquad4k remote control

### DIFF
--- a/plugin/controllers/views/main.tmpl
+++ b/plugin/controllers/views/main.tmpl
@@ -304,7 +304,7 @@
 							<td data-code="141" class="tdf"><button class="_12">Setup</button></td>
 							<td data-code="156" class="tdf"><button class="_11">Portal</button></td>
 							<td data-code="142" class="tdf"><button class="_12">Sleep</button></td>
-							<td data-code="359" class="tdf"><button class="_12">Timer</button></td>
+							<td data-code="362" class="tdf"><button class="_12">Timer</button></td>
 						<tr>
 						</table>
 						<table class="remotesmall" style="height:20px;">


### PR DESCRIPTION
timer with data code 359 in remote small initiates a time-shift instead listing of programmed timers in gbquad4k receivers. The correct data code is 362.

The sourcetext of the openwebinterface inside firefox shows the wrong content as this main.tmpl

for a quick temporary solution i patched the resulting 
/usr/lib/enigma2/python/Plugins/Extensions/OpenWebif/controllers/views/main.pyc
which can be compiled from the template main.tmpl via
cheetah compile --nobackup --iext=.tmpl -R /usr/lib/enigma2/python/Plugins/Extensions/OpenWebif/controllers/views/

I've already created an issue #68 with the title
"The Timer key in Complete Remote Control in OpenWebif starts a time-shift instead of showing the programmed Timers"

