### PR TITLE
Fix EIT handling when creating timers.

### DIFF
--- a/plugin/controllers/web.py
+++ b/plugin/controllers/web.py
@@ -1165,8 +1165,14 @@ class WebController(BaseController):
 					"result": False,
 					"message": "The parameter 'eventid' must be a number"
 				}
-		elif b"eit" in list(request.args.keys()) and isinstance(request.args[b"eit"][0], int):
-			eit = int(request.args[b"eit"][0])
+		elif b"eit" in request.args:
+			try:
+				eit = int(request.args[b"eit"][0])
+			except (TypeError, ValueError):
+				return {
+					"result": False,
+					"message": "The parameter 'eit' must be a number"
+				}
 		else:
 			# This might need further investigation. Do not get exactly the middle, take 20% so we usually expect to get first event.
 			queryTime = int(request.args[b"begin"][0]) + (int(request.args[b"end"][0]) - int(request.args[b"begin"][0])) // 5


### PR DESCRIPTION
- the received EIT was always ignored because of an incorrect int type check, causing an unnecessary EPG lookup by time. If that lookup failed, the timer was stored with eit=0.